### PR TITLE
Input generator

### DIFF
--- a/src/aircrafts/aircrafts/C310.jl
+++ b/src/aircrafts/aircrafts/C310.jl
@@ -251,8 +251,9 @@ cnda(aero::C310Aerodynamics, da) = -0.0168 * da
 cndr(aero::C310Aerodynamics, dr) = -0.1152 * dr
 
 # FORCES
-function calculate_aerodynamics(ac::Aircraft, aero::C310Aerodynamics, fcs::FCS,
-    aerostate::AeroState, state::State)
+function calculate_aerodynamics(
+    ac::Aircraft, aero::C310Aerodynamics, aerostate::AeroState, state::State
+    )
 
     ARP = get_arp(ac)
 
@@ -260,6 +261,8 @@ function calculate_aerodynamics(ac::Aircraft, aero::C310Aerodynamics, fcs::FCS,
     Sw = get_wing_area(ac)
     b = get_wing_span(ac)
     c = get_chord(ac)
+
+    fcs = get_fcs(ac)
 
     de = get_value(fcs.de)  # rad
     da = get_value(fcs.da)  # rad
@@ -335,8 +338,7 @@ get_engine_position(prop::C310EngineRight) = [-27.5, 70, 15.5] .* IN2M
 get_engine_orientation(prop::C310Engine) = [0, 0, 0] .* DEG2RAD
 
 
-function calculate_engine_power(eng::C310Engine, fcs::FCS,
-                                aerostate::AeroState, state::State)
+function calculate_engine_power(eng::C310Engine, fcs::FCS, aerostate::AeroState, state::State)
    # Max power at sea level
    Pmax0 = 260 * HP2WAT
    # Power assumed proportional to thrust lever
@@ -348,8 +350,9 @@ function calculate_engine_power(eng::C310Engine, fcs::FCS,
    return Pm, cj
 end
 
-function calculate_propeller_thrust(eng::C310Engine, fcs::FCS,
-    aerostate::AeroState, state::State, Pm::Number)
+function calculate_propeller_thrust(
+    eng::C310Engine, fcs::FCS, aerostate::AeroState, state::State, Pm::Number
+    )
    # Assume constant propulsive efficiency
    ηp = 0.75
    # Calculate thrust
@@ -358,8 +361,9 @@ function calculate_propeller_thrust(eng::C310Engine, fcs::FCS,
 end
 
 
-function calculate_engine(eng::C310Engine, fcs::FCS, aerostate::AeroState,
-                          state::State; consume_fuel=false)
+function calculate_engine(
+    eng::C310Engine, fcs::FCS, aerostate::AeroState, state::State; consume_fuel=false
+    )
     Pm, cj = calculate_engine_power(eng, fcs, aerostate, state)
     thrust, ηp = calculate_propeller_thrust(eng, fcs, aerostate, state, Pm)
 

--- a/src/aircrafts/aircrafts/C310.jl
+++ b/src/aircrafts/aircrafts/C310.jl
@@ -107,6 +107,7 @@ struct C310<:Aircraft
 
     aerodynamics::C310Aerodynamics
     propulsion::Propulsion
+    fcs::FCS
 end
 
 
@@ -476,15 +477,18 @@ function C310()
             [0., 0., 0.]
             )
 
+    fcs = C310FCS()
     # mass properties cannot be retrieved until ac is created... so:
     ac = C310(RigidSolid(0, zeros(3), zeros(3, 3)),
               pfm0,
               aero0,
-              propulsion0)
+              propulsion0,
+              fcs)
     mass = get_fuel_mass_props(get_propulsion(ac)) +
            get_empty_mass_props(ac) +
            get_payload_mass_props(ac)
-    C310(mass, pfm0, aero0, propulsion0)
+
+    C310(mass, pfm0, aero0, propulsion0, fcs)
 end
 
 # Name

--- a/src/aircrafts/aircrafts/C310.jl
+++ b/src/aircrafts/aircrafts/C310.jl
@@ -18,7 +18,9 @@ import FlightMechanics.Models:
 # Aircraft Model
 import FlightMechanics.Models:
     get_name, get_wing_area, get_wing_span, get_chord, get_arp,
-    get_empty_mass_props, get_payload_mass_props
+    get_empty_mass_props, get_payload_mass_props,
+    set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
+    set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer
 
 
 ##----------------------------------------------------------------------------------------------------
@@ -36,10 +38,7 @@ export C310Engine, C310EngineLeft, C310EngineRight,
 
 # FCS
 export C310FCS,
-    set_stick_lon!, set_stick_lat!, set_pedals!,
-    set_thtl1!, set_thtl2!, set_thtl!,
-    set_controls_trimmer!, get_controls_trimmer,
-    get_controls_ranges_trimmer
+    set_thtl1!, set_thtl2!
 
 # Aircraft Model
 export C310,

--- a/src/aircrafts/aircrafts/C310.jl
+++ b/src/aircrafts/aircrafts/C310.jl
@@ -20,7 +20,7 @@ import FlightMechanics.Models:
     get_name, get_wing_area, get_wing_span, get_chord, get_arp,
     get_empty_mass_props, get_payload_mass_props,
     set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
-    set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer
+    get_controls_ranges_trimmer
 
 
 ##----------------------------------------------------------------------------------------------------
@@ -442,21 +442,6 @@ function set_thtl!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=fa
     set_thtl1!(fcs, value, allow_out_of_range, throw_error)
     set_thtl2!(fcs, value, allow_out_of_range, throw_error)
 end
-
-function set_controls_trimmer!(fcs::C310FCS, slong, slat, ped, thtl,
-    allow_out_of_range=true, throw_error=false)
-    set_stick_lat!(fcs, slong, allow_out_of_range, throw_error)
-    set_stick_lon!(fcs, slat, allow_out_of_range, throw_error)
-    set_pedals!(fcs, ped, allow_out_of_range, throw_error)
-    set_thtl!(fcs, thtl, allow_out_of_range, throw_error)
-end
-
-function get_controls_trimmer(fcs::C310FCS)
-    [get_value(fcs.stick_longitudinal),
-     get_value(fcs.stick_lateral),
-     get_value(fcs.pedals),
-     get_value(fcs.thtl)]
- end
 
 function get_controls_ranges_trimmer(fcs::C310FCS)
     [get_value_range(fcs.stick_longitudinal),

--- a/src/aircrafts/aircrafts/C310.jl
+++ b/src/aircrafts/aircrafts/C310.jl
@@ -84,7 +84,7 @@ struct C310EngineRight<:C310Engine
 end
 
 # FCS
-struct C310FCS<:FCS
+mutable struct C310FCS<:FCS
     # Cabin controls
     stick_longitudinal::RangeControl
     stick_lateral::RangeControl
@@ -98,7 +98,12 @@ struct C310FCS<:FCS
     # Engine
     t1::RangeControl
     t2::RangeControl
+    # Configuration
+    allow_out_of_range::Bool
+    throw_error_on_out_of_range::Bool
+
 end
+
 
 # Aircraft Model
 struct C310<:Aircraft
@@ -390,57 +395,73 @@ get_thrust_setting(eng::C310EngineRight, fcs::FCS) = get_value(fcs.t2)
 ##----------------------------------------------------------------------------------------------------
 ## FCS
 
-C310FCS() = C310FCS(# Cabin Inputs
-                    RangeControl(0.0, [0, 1]),  # stick_longitudinal
-                    RangeControl(0.0, [0, 1]),  # stick_lateral
-                    RangeControl(0.0, [0, 1]),  # pedals
-                    RangeControl(0.0, [0, 1]),  # thtl
-                    # Controls
-                    RangeControl(0.0, [-25.0, 35.0] .* DEG2RAD),  # elevator
-                    RangeControl(0.0, [-18.0, 14.0] .* DEG2RAD),  # ailerons
-                    RangeControl(0.0, [-27.0, 27.0] .* DEG2RAD),  # rudder
-                    RangeControl(0.0, [0.0, 1.0]),                # t1
-                    RangeControl(0.0, [0.0, 1.0])                 # t1
-                    )
+C310FCS(stick_lon, stick_lat, pedals, thtl, de, da, dr, t1, t2) = C310FCS(
+    stick_lon, stick_lat, pedals, thtl, de, da, dr, t1, t2, false, false
+    )
 
-function set_stick_lon!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
+C310FCS() = C310FCS(
+    # Cabin Inputs
+    RangeControl(0.0, [0, 1]),  # stick_longitudinal
+    RangeControl(0.0, [0, 1]),  # stick_lateral
+    RangeControl(0.0, [0, 1]),  # pedals
+    RangeControl(0.0, [0, 1]),  # thtl
+    # Controls
+    RangeControl(0.0, [-25.0, 35.0] .* DEG2RAD),  # elevator
+    RangeControl(0.0, [-18.0, 14.0] .* DEG2RAD),  # ailerons
+    RangeControl(0.0, [-27.0, 27.0] .* DEG2RAD),  # rudder
+    RangeControl(0.0, [0.0, 1.0]),                # t1
+    RangeControl(0.0, [0.0, 1.0])                 # t1
+    )
+
+
+function set_stick_lon!(fcs::C310FCS, value)
     set_value!(fcs.stick_longitudinal, value)
     min, max = get_value_range(fcs.de)
     range = max - min
+    allow_out_of_range = get_allow_out_of_range_inputs(fcs)
+    throw_error = get_throw_error_on_out_of_range_inputs(fcs)
     set_value!(fcs.de, min + range * value, allow_out_of_range, throw_error)
 end
 
-function set_stick_lat!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
+function set_stick_lat!(fcs::C310FCS, value)
     set_value!(fcs.stick_lateral, value)
     min, max = get_value_range(fcs.da)
     range = max - min
+    allow_out_of_range = get_allow_out_of_range_inputs(fcs)
+    throw_error = get_throw_error_on_out_of_range_inputs(fcs)
     set_value!(fcs.da, min + range * value, allow_out_of_range, throw_error)
 end
 
-function set_pedals!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
+function set_pedals!(fcs::C310FCS, value)
     set_value!(fcs.pedals, value)
     min, max = get_value_range(fcs.dr)
     range = max - min
+    allow_out_of_range = get_allow_out_of_range_inputs(fcs)
+    throw_error = get_throw_error_on_out_of_range_inputs(fcs)
     set_value!(fcs.dr, min + range * value, allow_out_of_range, throw_error)
 end
 
-function set_thtl1!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
+function set_thtl1!(fcs::C310FCS, value)
     set_value!(fcs.thtl, value)
     min, max = get_value_range(fcs.t1)
     range = max - min
+    allow_out_of_range = get_allow_out_of_range_inputs(fcs)
+    throw_error = get_throw_error_on_out_of_range_inputs(fcs)
     set_value!(fcs.t1, min + range * value, allow_out_of_range, throw_error)
 end
 
-function set_thtl2!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
+function set_thtl2!(fcs::C310FCS, value)
     set_value!(fcs.thtl, value)
     min, max = get_value_range(fcs.t2)
     range = max - min
+    allow_out_of_range = get_allow_out_of_range_inputs(fcs)
+    throw_error = get_throw_error_on_out_of_range_inputs(fcs)
     set_value!(fcs.t2, min + range * value, allow_out_of_range, throw_error)
 end
 
-function set_thtl!(fcs::C310FCS, value, allow_out_of_range=false, throw_error=false)
-    set_thtl1!(fcs, value, allow_out_of_range, throw_error)
-    set_thtl2!(fcs, value, allow_out_of_range, throw_error)
+function set_thtl!(fcs::C310FCS, value)
+    set_thtl1!(fcs, value)
+    set_thtl2!(fcs, value)
 end
 
 function get_controls_ranges_trimmer(fcs::C310FCS)
@@ -449,7 +470,6 @@ function get_controls_ranges_trimmer(fcs::C310FCS)
      get_value_range(fcs.pedals),
      get_value_range(fcs.thtl)]
 end
-
 
 ##----------------------------------------------------------------------------------------------------
 ## Aircraft Model

--- a/src/aircrafts/aircrafts/F16.jl
+++ b/src/aircrafts/aircrafts/F16.jl
@@ -354,8 +354,9 @@ Cnda(aero::F16Aerodynamics, α, β, da) = Cn_da(aero, α, β) * da
 
 
 
-function calculate_aerodynamics(ac::Aircraft, aero::F16Aerodynamics, fcs::FCS,
-   aerostate::AeroState, state::State)
+function calculate_aerodynamics(
+    ac::Aircraft, aero::F16Aerodynamics, aerostate::AeroState, state::State
+    )
 
    ARP = get_arp(ac)
 
@@ -364,6 +365,7 @@ function calculate_aerodynamics(ac::Aircraft, aero::F16Aerodynamics, fcs::FCS,
    b = get_wing_span(ac)  # m
    c = get_chord(ac)  # m
 
+   fcs = get_fcs(ac)
    de = get_value(fcs.de) * RAD2DEG
    da = get_value(fcs.da) * RAD2DEG
    dr = get_value(fcs.dr) * RAD2DEG
@@ -583,8 +585,9 @@ Reimplemented from:
  and simulation: dynamics, controls design, and autonomous systems. John Wiley
  & Sons. (page 715)
 """
-function calculate_engine(eng::F16Engine, fcs::FCS, aerostate::AeroState,
-                          state::State; consume_fuel=false)
+function calculate_engine(
+    eng::F16Engine, fcs::FCS, aerostate::AeroState, state::State; consume_fuel=false
+    )
 
     pow = get_thrust(fcs)  # Commanded power: between 0 and 100
     Mach = get_mach(aerostate)

--- a/src/aircrafts/aircrafts/F16.jl
+++ b/src/aircrafts/aircrafts/F16.jl
@@ -19,7 +19,7 @@ import FlightMechanics.Models:
     get_name, get_wing_area, get_wing_span, get_chord, get_arp,
     get_empty_mass_props,
     set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
-    set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer
+    get_controls_ranges_trimmer
 
 
 ##----------------------------------------------------------------------------------------------------
@@ -662,21 +662,6 @@ function set_thtl!(fcs::F16FCS, value, allow_out_of_range=false, throw_error=fal
     range = max - min
     set_value!(fcs.cpl, tgear(value), allow_out_of_range, throw_error)
 end
-
-function set_controls_trimmer!(fcs::F16FCS, slong, slat, ped, thtl,
-    allow_out_of_range=true, throw_error=false)
-    set_stick_lat!(fcs, slong, allow_out_of_range, throw_error)
-    set_stick_lon!(fcs, slat, allow_out_of_range, throw_error)
-    set_pedals!(fcs, ped, allow_out_of_range, throw_error)
-    set_thtl!(fcs, thtl, allow_out_of_range, throw_error)
-end
-
-function get_controls_trimmer(fcs::F16FCS)
-    [get_value(fcs.stick_longitudinal),
-     get_value(fcs.stick_lateral),
-     get_value(fcs.pedals),
-     get_value(fcs.thtl)]
- end
 
 function get_controls_ranges_trimmer(fcs::F16FCS)
     [get_value_range(fcs.stick_longitudinal),

--- a/src/aircrafts/aircrafts/F16.jl
+++ b/src/aircrafts/aircrafts/F16.jl
@@ -17,7 +17,9 @@ import FlightMechanics.Models:
 # Aircraft Model
 import FlightMechanics.Models:
     get_name, get_wing_area, get_wing_span, get_chord, get_arp,
-    get_empty_mass_props
+    get_empty_mass_props,
+    set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
+    set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer
 
 
 ##----------------------------------------------------------------------------------------------------
@@ -33,11 +35,7 @@ export F16Engine,
     calculate_engine
 
 # FCS
-export F16FCS,
-    set_stick_lon!, set_stick_lat!, set_pedals!,
-    set_thtl!,
-    set_controls_trimmer!, get_controls_trimmer,
-    get_controls_ranges_trimmer
+export F16FCS
 
 # Aircraft Model
 export F16,

--- a/src/aircrafts/aircrafts/F16.jl
+++ b/src/aircrafts/aircrafts/F16.jl
@@ -90,6 +90,7 @@ struct F16<:Aircraft
     pfm::PointForcesMoments
     aerodynamics::F16Aerodynamics
     propulsion::Propulsion
+    fcs::FCS
 end
 
 
@@ -696,14 +697,16 @@ function F16()
             get_gyro_effects(engine)
             )
 
+    fcs = F16FCS()
     # mass properties cannot be retrieved until ac is created... so:
     ac = F16(RigidSolid(0, zeros(3), zeros(3, 3)),
               pfm0,
               aero0,
-              propulsion0)
+              propulsion0,
+              fcs)
     mass = get_fuel_mass_props(get_propulsion(ac)) + get_empty_mass_props(ac)
             # + get_payload_mass_props(ac)
-    F16(mass, pfm0, aero0, propulsion0)
+    F16(mass, pfm0, aero0, propulsion0, fcs)
 end
 
 

--- a/src/aircrafts/trimmer.jl
+++ b/src/aircrafts/trimmer.jl
@@ -95,6 +95,7 @@ function steady_state_trim(ac::Aircraft, controls::Controls, env::Environment,
     set_allow_out_of_range_inputs!(fcs, true)
     set_throw_error_on_out_of_range_inputs!(fcs, false)
 
+    # Ensure controls are applied to aircraft
     set_controls!(ac, controls)
 
     # Store every necessary variable in the trimmer
@@ -117,7 +118,7 @@ function steady_state_trim(ac::Aircraft, controls::Controls, env::Environment,
     # Calcualte cost function to check if a/c is already trimmed
     # Calcualte aircraft
     grav = env.grav
-    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel = false)
+    ac = calculate_aircraft(ac, controls, aerostate, state, grav; consume_fuel = false)
     trimmer.ac = ac
     cost = evaluate_cost_function(trimmer)
 
@@ -205,9 +206,8 @@ function trim_cost_function(x, trimmer::Trimmer)
 
     ac = trimmer.ac
     grav = env.grav
-    set_controls!(ac, controls)
     # Calcualte aircraft
-    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel = false)
+    ac = calculate_aircraft(ac, controls, aerostate, state, grav; consume_fuel = false)
 
     # Update trimmer
     trimmer.ac = ac

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -51,6 +51,10 @@ get_value,
 FCS,
 set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
 set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer,
+Controls, StickPedalsLeverControls,
+set_controls!,
+ControlsStream, StickPedalsLeverStream,
+get_controls,
 # Engine
 Engine, get_engine_position, get_engine_orientation, get_engine_gyro_effects,
 # Propulsion
@@ -81,10 +85,10 @@ include("gravity.jl")
 include("environment.jl")
 include("aero_state.jl")
 include("controls.jl")
+include("inputs.jl")
 include("fcs.jl")
 include("propulsion.jl")
 include("aerodynamics.jl")
 include("aircraft.jl")
 include("dynamic_systems.jl")
-include("inputs.jl")
 end

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -50,7 +50,7 @@ get_value,
 # FCS
 FCS,
 set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
-set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer,
+get_controls_ranges_trimmer,
 Controls, StickPedalsLeverControls,
 set_controls!, 
 get_controls_array, get_n_controls, get_stick_lon, get_stick_lat, get_pedals, get_thrust_lever,

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -52,7 +52,8 @@ FCS,
 set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
 set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer,
 Controls, StickPedalsLeverControls,
-set_controls!,
+set_controls!, 
+get_controls_array, get_n_controls, get_stick_lon, get_stick_lat, get_pedals, get_thrust_lever,
 ControlsStream, StickPedalsLeverStream,
 get_controls,
 # Engine
@@ -66,7 +67,7 @@ aerodynamics_from_body_total, aerodynamics_from_body_coeff, get_pfm,
 get_wind_pfm, get_wind_adim_pfm, get_body_pfm, get_body_adim_pfm,
 calculate_aerodynamics,
 # Aircraft
-Aircraft, get_mass_props, get_pfm, get_aerodynamics, get_propulsion, get_name,
+Aircraft, get_mass_props, get_pfm, get_aerodynamics, get_propulsion, get_fcs, get_name,
 get_wing_area, get_wing_span, get_chord, get_arp, get_empty_mass_props,
 get_payload_mass_props, calculate_aircraft,
 # DynamicSystem

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -43,6 +43,9 @@ generate_state_aerostate, check_state_aerostate_env_coherence,
 # Controls
 Control, RangeControl, DiscreteControl,
 get_value, get_value_range, get_value_choices, set_value!,
+# Inputs
+Input, ConstantInput, StepInput, RampInput, SinusoidalInput,
+get_value,
 # FCS
 FCS,
 # Engine
@@ -80,4 +83,5 @@ include("propulsion.jl")
 include("aerodynamics.jl")
 include("aircraft.jl")
 include("dynamic_systems.jl")
+include("inputs.jl")
 end

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -49,6 +49,8 @@ SinusoidalInput,
 get_value,
 # FCS
 FCS,
+set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
+set_controls_trimmer!, get_controls_trimmer, get_controls_ranges_trimmer,
 # Engine
 Engine, get_engine_position, get_engine_orientation, get_engine_gyro_effects,
 # Propulsion

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -44,7 +44,8 @@ generate_state_aerostate, check_state_aerostate_env_coherence,
 Control, RangeControl, DiscreteControl,
 get_value, get_value_range, get_value_choices, set_value!,
 # Inputs
-Input, ConstantInput, StepInput, RampInput, SinusoidalInput,
+Input, ConstantInput, StepInput, DoubletInput, InverseDoubletInput, RampInput,
+SinusoidalInput,
 get_value,
 # FCS
 FCS,

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -50,6 +50,8 @@ get_value,
 # FCS
 FCS,
 set_stick_lon!, set_stick_lat!, set_pedals!, set_thtl!,
+get_allow_out_of_range_inputs, get_throw_error_on_out_of_range_inputs,
+set_allow_out_of_range_inputs!, set_throw_error_on_out_of_range_inputs!,
 get_controls_ranges_trimmer,
 Controls, StickPedalsLeverControls,
 set_controls!, 

--- a/src/models/aircraft.jl
+++ b/src/models/aircraft.jl
@@ -5,6 +5,7 @@ get_mass_props(ac::Aircraft) = ac.mass_props
 get_pfm(ac::Aircraft) = ac.pfm
 get_aerodynamics(ac::Aircraft) = ac.aerodynamics
 get_propulsion(ac::Aircraft) = ac.propulsion
+get_fcs(ac::Aircraft) = ac.fcs
 
 get_name(ac::Aircraft) = "Generic Aricraft"
 get_wing_area(ac::Aircraft) = 0.0  # m²
@@ -44,5 +45,5 @@ function calculate_aircraft(ac::Aircraft, fcs::FCS, aerostate::AeroState,
         get_payload_mass_props(ac)
         )
     # Return aircraft object
-    typeof(ac)(mass_props, pfm, aero, prop)
+    typeof(ac)(mass_props, pfm, aero, prop, fcs)
 end

--- a/src/models/aircraft.jl
+++ b/src/models/aircraft.jl
@@ -24,12 +24,15 @@ end
 
 
 function calculate_aircraft(
-    ac::Aircraft, aerostate::AeroState, state::State, grav::Gravity; consume_fuel=false
+    ac::Aircraft, controls::Controls, aerostate::AeroState, state::State, grav::Gravity;
+    consume_fuel=false
     )
+
     aero = get_aerodynamics(ac)
     prop = get_propulsion(ac)
     mass_props = get_mass_props(ac)
     
+    set_controls!(ac, controls)
     fcs = get_fcs(ac)
     # Calculate propulsion
     prop = calculate_propulsion(prop, fcs, aerostate, state; consume_fuel=consume_fuel)

--- a/src/models/aircraft.jl
+++ b/src/models/aircraft.jl
@@ -17,13 +17,9 @@ get_empty_mass_props(ac::Aircraft) = RigidSolid(0.0, zeros(3), zeros(3, 3))
 get_payload_mass_props(ac::Aircraft) = RigidSolid(0.0, zeros(3), zeros(3, 3))
 
 
-function set_controls!(ac::Aircraft, c::Controls; allow_out_of_range=false, throw_error=false)
+function set_controls!(ac::Aircraft, c::Controls)
     fcs = get_fcs(ac)
-    set_controls!(
-        fcs, c::StickPedalsLeverControls; 
-        allow_out_of_range=allow_out_of_range,
-        throw_error=throw_error
-        )
+    set_controls!(fcs, c::StickPedalsLeverControls)
 end
 
 

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -1,5 +1,18 @@
 abstract type FCS end
 
+
+# Interface that must be implemented
+function set_stick_lon! end
+function set_stick_lat! end
+function set_pedals! end
+function set_thtl! end
+
+# Interface to be trimmed
+function set_controls_trimmer! end
+function get_controls_trimmer end
+function get_controls_ranges_trimmer end
+
+
 function copy(fcs::FCS)
     fcs_type = typeof(fcs)
     fcs_ = fcs_type(

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -1,5 +1,5 @@
+# -------------------- FCS --------------------
 abstract type FCS end
-
 
 # Interface that must be implemented
 function set_stick_lon! end
@@ -19,4 +19,76 @@ function copy(fcs::FCS)
         [copy(getfield(fcs, name)) for name in fieldnames(fcs_type)]...
         )
     return fcs_
+end
+
+# -------------------- Controls --------------------
+"Controls are the input to a FCS."
+abstract type Controls end
+
+# Interface that must be implemented
+"""
+    set_controls!(fcs, controls)
+
+Sets a FCS with the given controls.
+"""
+function set_controls! end
+
+
+"""
+    StickPedalsLeverControls(stick_lon, stick_lat, pedals, thrust_lever)
+
+Classical controls stick longitudinal and lateral setting, pedals, and thrust lever.
+"""
+struct StickPedalsLeverControls <: Controls
+    stick_lon :: Number
+    stick_lat :: Number
+    pedals :: Number
+    thrust_lever :: Number
+end
+
+
+function set_controls!(fcs::FCS, c::StickPedalsLeverControls)
+    set_stick_lon!(fcs, c.stick_lon)
+    set_stick_lat!(fcs, c.stick_lat)
+    set_pedals!(fcs, c.pedals)
+    set_thtl!(fcs, c.thrust_lever)
+end
+
+
+# -------------------- ControlsStream --------------------
+"""
+Controls are defined normally in a strem (function or callable) that returns the control
+value a certain time.
+"""
+abstract type ControlsStream end
+
+# Interface that must be implemented
+"""
+    get_controls(cs::ControlsStream, t)
+
+Get the control values of a control stream at a certain instant t. Return Controls.
+"""
+function get_controls end
+
+
+"""
+    StickPedalsLeverStream(stick_lon, stick_lat, pedals, thrust_lever)
+
+Classical controls stick longitudinal and lateral setting, pedals, and thrust lever.
+Inputs are of type Input or Array{T, 1} where T<:Input
+"""
+struct StickPedalsLeverStream <: ControlsStream
+    stick_lon_stream :: Union{Input, Array{T, 1}} where T<:Input
+    stick_lat_stream :: Union{Input, Array{T, 1}} where T<:Input
+    pedals_stream :: Union{Input, Array{T, 1}} where T<:Input
+    thrust_lever_stream :: Union{Input, Array{T, 1}} where T<:Input
+end
+
+
+function get_controls(cs::StickPedalsLeverStream, t)
+    slon = get_value(cs.stick_lon_stream, t)
+    slat = get_value(cs.stick_lat_stream, t)
+    ped = get_value(cs.pedals_stream, t)
+    lev = get_value(cs.thrust_lever_stream, t)
+    return StickPedalsLeverControls(slon, slat, ped, lev)
 end

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -36,10 +36,13 @@ if throw_error is false (otherwise an error will be thrown)
 """
 function set_controls! end
 
+function get_controls_array end
 function get_stick_lon end
 function get_stick_lat end
 function get_pedals end
 function get_thrust_lever end
+
+get_n_controls(c::Controls) = size(get_controls_array)
 
 
 """
@@ -55,6 +58,9 @@ struct StickPedalsLeverControls <: Controls
 end
 
 
+get_controls_array(c::StickPedalsLeverControls) = [
+    get_stick_lon(c), get_stick_lat(c), get_pedals(c), get_thrust_lever(c)
+    ]
 get_stick_lon(c::StickPedalsLeverControls) = c.stick_lon
 get_stick_lat(c::StickPedalsLeverControls) = c.stick_lat
 get_pedals(c::StickPedalsLeverControls) = c.pedals

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -27,9 +27,12 @@ abstract type Controls end
 
 # Interface that must be implemented
 """
-    set_controls!(fcs, controls)
+    set_controls!(fcs, controls; allow_out_of_range=false, throw_error=false)
 
 Sets a FCS with the given controls.
+If allow_out_of_range values outside the range will be allowed. This is useful in some
+situations such as the trimming process. Otherwise, the values will be set to the limit
+if throw_error is false (otherwise an error will be thrown)
 """
 function set_controls! end
 
@@ -47,11 +50,13 @@ struct StickPedalsLeverControls <: Controls
 end
 
 
-function set_controls!(fcs::FCS, c::StickPedalsLeverControls)
-    set_stick_lon!(fcs, c.stick_lon)
-    set_stick_lat!(fcs, c.stick_lat)
-    set_pedals!(fcs, c.pedals)
-    set_thtl!(fcs, c.thrust_lever)
+function set_controls!(
+    fcs::FCS, c::StickPedalsLeverControls; allow_out_of_range=false, throw_error=false
+    )
+    set_stick_lon!(fcs, c.stick_lon, allow_out_of_range, throw_error)
+    set_stick_lat!(fcs, c.stick_lat, allow_out_of_range, throw_error)
+    set_pedals!(fcs, c.pedals, allow_out_of_range, throw_error)
+    set_thtl!(fcs, c.thrust_lever, allow_out_of_range, throw_error)
 end
 
 

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -36,6 +36,11 @@ if throw_error is false (otherwise an error will be thrown)
 """
 function set_controls! end
 
+function get_stick_lon end
+function get_stick_lat end
+function get_pedals end
+function get_thrust_lever end
+
 
 """
     StickPedalsLeverControls(stick_lon, stick_lat, pedals, thrust_lever)
@@ -50,13 +55,19 @@ struct StickPedalsLeverControls <: Controls
 end
 
 
+get_stick_lon(c::StickPedalsLeverControls) = c.stick_lon
+get_stick_lat(c::StickPedalsLeverControls) = c.stick_lat
+get_pedals(c::StickPedalsLeverControls) = c.pedals
+get_thrust_lever(c::StickPedalsLeverControls) = c.thrust_lever
+
+
 function set_controls!(
     fcs::FCS, c::StickPedalsLeverControls; allow_out_of_range=false, throw_error=false
     )
-    set_stick_lon!(fcs, c.stick_lon, allow_out_of_range, throw_error)
-    set_stick_lat!(fcs, c.stick_lat, allow_out_of_range, throw_error)
-    set_pedals!(fcs, c.pedals, allow_out_of_range, throw_error)
-    set_thtl!(fcs, c.thrust_lever, allow_out_of_range, throw_error)
+    set_stick_lon!(fcs, get_stick_lon(c), allow_out_of_range, throw_error)
+    set_stick_lat!(fcs, get_stick_lat(c), allow_out_of_range, throw_error)
+    set_pedals!(fcs, get_pedals(c), allow_out_of_range, throw_error)
+    set_thtl!(fcs, get_thrust_lever(c), allow_out_of_range, throw_error)
 end
 
 

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -7,6 +7,38 @@ function set_stick_lat! end
 function set_pedals! end
 function set_thtl! end
 
+"""
+If allow_out_of_range, values outside the range will be allowed. This is useful in some
+situations such as the trimming process. Otherwise, the values will be set to the limit
+if throw_error is false (otherwise an error will be thrown)
+"""
+get_allow_out_of_range_inputs(fcs::FCS) = fcs.allow_out_of_range
+"""
+If allow_out_of_range, values outside the range will be allowed. This is useful in some
+situations such as the trimming process. Otherwise, the values will be set to the limit
+if throw_error is false (otherwise an error will be thrown)
+"""
+get_throw_error_on_out_of_range_inputs(fcs::FCS) = fcs.throw_error_on_out_of_range
+
+"""
+If allow_out_of_range, values outside the range will be allowed. This is useful in some
+situations such as the trimming process. Otherwise, the values will be set to the limit
+if throw_error is false (otherwise an error will be thrown)
+"""
+function set_allow_out_of_range_inputs!(fcs::FCS, val::Bool)
+    fcs.allow_out_of_range = val
+end
+
+"""
+If allow_out_of_range, values outside the range will be allowed. This is useful in some
+situations such as the trimming process. Otherwise, the values will be set to the limit
+if throw_error is false (otherwise an error will be thrown)
+"""
+function set_throw_error_on_out_of_range_inputs!(fcs::FCS, val::Bool)
+    fcs.throw_error_on_out_of_range = val
+end
+
+
 # Interface to be trimmed
 function get_controls_ranges_trimmer end
 
@@ -25,12 +57,9 @@ abstract type Controls end
 
 # Interface that must be implemented
 """
-    set_controls!(fcs, controls; allow_out_of_range=false, throw_error=false)
+    set_controls!(fcs, controls)
 
 Sets a FCS with the given controls.
-If allow_out_of_range values outside the range will be allowed. This is useful in some
-situations such as the trimming process. Otherwise, the values will be set to the limit
-if throw_error is false (otherwise an error will be thrown)
 """
 function set_controls! end
 
@@ -65,13 +94,11 @@ get_pedals(c::StickPedalsLeverControls) = c.pedals
 get_thrust_lever(c::StickPedalsLeverControls) = c.thrust_lever
 
 
-function set_controls!(
-    fcs::FCS, c::StickPedalsLeverControls; allow_out_of_range=false, throw_error=false
-    )
-    set_stick_lon!(fcs, get_stick_lon(c), allow_out_of_range, throw_error)
-    set_stick_lat!(fcs, get_stick_lat(c), allow_out_of_range, throw_error)
-    set_pedals!(fcs, get_pedals(c), allow_out_of_range, throw_error)
-    set_thtl!(fcs, get_thrust_lever(c), allow_out_of_range, throw_error)
+function set_controls!(fcs::FCS, c::StickPedalsLeverControls)
+    set_stick_lon!(fcs, get_stick_lon(c))
+    set_stick_lat!(fcs, get_stick_lat(c))
+    set_pedals!(fcs, get_pedals(c))
+    set_thtl!(fcs, get_thrust_lever(c))
 end
 
 

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -8,8 +8,6 @@ function set_pedals! end
 function set_thtl! end
 
 # Interface to be trimmed
-function set_controls_trimmer! end
-function get_controls_trimmer end
 function get_controls_ranges_trimmer end
 
 

--- a/src/models/inputs.jl
+++ b/src/models/inputs.jl
@@ -1,0 +1,92 @@
+abstract type Input end
+
+
+"""
+    get_value(input::Constant, time)
+
+Get input value at time t.
+"""
+function get_value end
+
+
+"""
+    ConstantInput(val)
+
+Constant value input.
+"""
+struct ConstantInput <: Input
+    val::Float64
+end
+
+
+"""
+    StepInput(val, tini, tfin)
+
+Step input. Takes value from tini to tfin and 0 otherwise.
+"""
+struct StepInput <: Input
+    val::Float64
+    tini::Float64
+    tfin::Float64
+end
+
+
+"""
+    RampInput(val, tini, tend)
+
+Ramp input. Takes value at tend increasing linearly from tini to tend.
+"""
+struct RampInput <: Input
+    val::Float64
+    tini::Float64
+    tfin::Float64
+end
+
+
+"""
+    SinusoidalInput(A, f, ϕ, tini, tfin)
+
+Sinusoidal input. Takes a A/2 * sin(2πf (t-tini) + ϕ) value between tini and tfin.
+Value is 0 otherwise.
+"""
+struct SinusoidalInput <: Input
+    "Peak to peak amplitude"
+    A::Float64
+    "Frequency (1/s)"
+    f::Float64
+    "Phase (rad)"
+    ϕ::Float64
+    tini::Float64
+    tfin::Float64
+end
+
+
+# --------- get_value methods ---------
+get_value(input::ConstantInput, time) = input.val
+get_value(input::StepInput, time) = input.tini <= time < input.tfin ? input.val : 0.
+
+function get_value(input::RampInput, time)
+    if input.tini <= time < input.tfin
+        return input.val * (time - input.tini) / (input.tfin - input.tini)
+    else
+        return 0.
+    end
+end
+
+
+function get_value(input::SinusoidalInput, time)
+    if input.tini <= time < input.tfin
+        return 0.5 * input.A * sin(2π * input.f * (time - input.tini) + input.ϕ)
+    else
+        return 0.
+    end
+end
+
+
+function get_value(input_arr::Array{T,1}, t) where T<:Input
+    value = 0.0
+    for input in input_arr
+        value = value + get_value(input, t)
+    end
+    return value
+end

--- a/src/models/inputs.jl
+++ b/src/models/inputs.jl
@@ -32,6 +32,28 @@ end
 
 
 """
+    DoubletInput(val, tini, tfin)
+
+Symmetric doublet input with val peak to peak amplitude. First positive.
+"""
+DoubletInput(val, tini, tfin) = vcat(
+    StepInput(0.5*val, tini, 0.5*(tini+tfin)),
+    StepInput(-0.5*val, 0.5*(tini+tfin), tfin)
+)
+
+
+"""
+    InverseDoubletInput(val, tini, tfin)
+
+Symmetric doublet input with val peak to peak amplitude. First negative.
+"""
+InverseDoubletInput(val, tini, tfin) = vcat(
+    StepInput(-0.5*val, tini, 0.5*(tini+tfin)),
+    StepInput(0.5*val, 0.5*(tini+tfin), tfin)
+)
+
+
+"""
     RampInput(val, tini, tend)
 
 Ramp input. Takes value at tend increasing linearly from tini to tend.

--- a/src/models/propulsion.jl
+++ b/src/models/propulsion.jl
@@ -57,8 +57,9 @@ end
 get_fuel_mass_props(prop::Propulsion) = sum(get_tanks(prop))
 
 
-function calculate_propulsion(prop::Propulsion, fcs::FCS, aerostate::AeroState,
-                              state::State; consume_fuel=false)
+function calculate_propulsion(
+    prop::Propulsion, fcs::FCS, aerostate::AeroState, state::State; consume_fuel=false
+    )
 
     engines = get_engines(prop)
 

--- a/test/aircrafts/c310.jl
+++ b/test/aircrafts/c310.jl
@@ -21,14 +21,11 @@ state = State(pos, att, [65., 0., 3.], [0., 0., 0.], [0., 0., 0.], [0., 0., 0.])
 env = Environment(pos, atmos="ISA1978", wind="NoWind", grav="const")
 aerostate = AeroState(state, env)
 
-fcs = C310FCS()
-set_stick_lon!(fcs, 0.43)
-set_stick_lat!(fcs, 0.562)
-set_pedals!(fcs, 0.5)
-set_thtl!(fcs, 0.68)
+controls = StickPedalsLeverControls(0.43, 0.562, 0.5, 0.68)
+set_controls!(ac, controls)
 
 grav = get_gravity(env)
-ac = calculate_aircraft(ac, fcs, aerostate, state, grav; consume_fuel=false)
+ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
 
 tas = 50  # m/s
 h = 300  # m
@@ -37,7 +34,8 @@ gamma = 5 * DEG2RAD
 turn_rate = 0.0
 
 ac, aerostate, state, fcs = steady_state_trim(
-    ac, fcs, env, tas, pos, psi, gamma, turn_rate, 5.0*DEG2RAD, 0.0*DEG2RAD)
+    ac, controls, env, tas, pos, psi, gamma, turn_rate, 5.0*DEG2RAD, 0.0*DEG2RAD
+    )
 
 @test isapprox(ac.pfm.forces, zeros(3), atol=1e-5)
 @test isapprox(ac.pfm.moments, zeros(3), atol=1e-5)

--- a/test/aircrafts/c310.jl
+++ b/test/aircrafts/c310.jl
@@ -22,10 +22,9 @@ env = Environment(pos, atmos="ISA1978", wind="NoWind", grav="const")
 aerostate = AeroState(state, env)
 
 controls = StickPedalsLeverControls(0.43, 0.562, 0.5, 0.68)
-set_controls!(ac, controls)
 
 grav = get_gravity(env)
-ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
+ac = calculate_aircraft(ac, controls, aerostate, state, grav; consume_fuel=false)
 
 tas = 50  # m/s
 h = 300  # m

--- a/test/aircrafts/f16.jl
+++ b/test/aircrafts/f16.jl
@@ -525,17 +525,24 @@ end
                   [0., 0., 0.]
                  )
 
-    fcs = get_fcs(ac)
-    set_value!(fcs.de, 20.0*DEG2RAD)
-    set_value!(fcs.da, -15.0*DEG2RAD)
-    set_value!(fcs.dr, -20*DEG2RAD)
-    set_value!(fcs.cpl, 90.0)
+    # Set controls to obtain the following deflexions
+    # fcs = get_fcs(ac)
+    # set_value!(fcs.de, 20.0*DEG2RAD)
+    # set_value!(fcs.da, -15.0*DEG2RAD)
+    # set_value!(fcs.dr, -20*DEG2RAD)
+    # set_value!(fcs.cpl, 90.0)
+    controls = StickPedalsLeverControls(
+        0.5 * (1 + 20 / 25),  # According to DE_MAX
+        0.5 * (1 - 15 / 20),  # According to DA_MAX
+        0.5 * (1 - 20 / 30),  # According to DR_MAX
+        (90.0 + 117.38) / 217.38  # According to tgear
+    )
 
     env = Environment(pos, atmos="ISAF16", wind="NoWind", grav="const")
     aerostate = AeroState(state, env)
     grav = get_gravity(env)
 
-    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
+    ac = calculate_aircraft(ac, controls, aerostate, state, grav; consume_fuel=false)
     pfm = ac.pfm
     mass_props = get_mass_props(ac)
     mass = mass_props.mass

--- a/test/aircrafts/f16.jl
+++ b/test/aircrafts/f16.jl
@@ -103,7 +103,7 @@ end
     att = Attitude(-1, 1, -1)
     pos = EarthPosition(1000*FT2M, 900*FT2M, -10000*FT2M)
     env = Environment(pos, atmos="ISA1978", wind="NoWind", grav="const")
-    fcs = F16FCS()
+    fcs = get_fcs(ac)
 
 
     @testset "Case $ii" for ii=1:size(input_data, 1)
@@ -118,6 +118,7 @@ end
                       [0., 0., 0.],
                       [0., 0., 0.]
                      )
+        # Act directly on FCS surfaces
         set_value!(fcs.de, de*DEG2RAD)
         set_value!(fcs.da, da*DEG2RAD)
         set_value!(fcs.dr, dr*DEG2RAD)
@@ -126,7 +127,7 @@ end
 
         # Calculate aerodynamics
         aero = get_aerodynamics(ac)
-        aero = calculate_aerodynamics(ac, aero, fcs, aerostate, state)
+        aero = calculate_aerodynamics(ac, aero, aerostate, state)
 
         pfm = get_body_adim_pfm(aero)
 
@@ -160,7 +161,7 @@ end
     att = Attitude(-1, 1, -1)
     pos = EarthPosition(1000*FT2M, 900*FT2M, -10000*FT2M)
     env = Environment(pos, atmos="ISA1978", wind="NoWind", grav="const")
-    fcs = F16FCS()
+    fcs = get_fcs(ac)
 
 
     @testset "Case $ii" for ii=1:size(input_data, 1)
@@ -183,7 +184,7 @@ end
 
         # Calculate aerodynamics
         aero = get_aerodynamics(ac)
-        aero = calculate_aerodynamics(ac, aero, fcs, aerostate, state)
+        aero = calculate_aerodynamics(ac, aero, aerostate, state)
 
         pfm = get_body_adim_pfm(aero)
 
@@ -214,8 +215,9 @@ end
            1.0        10000      500      77931.4105074207
     ]
 
+    ac = F16()
     eng = F16Engine()
-    fcs = F16FCS()
+    fcs = get_fcs(ac)
     att = Attitude(0., 0., 0.)
     pos = EarthPosition(0, 0, 0)
     env = Environment(pos, atmos="ISAF16", wind="NoWind", grav="const")
@@ -242,12 +244,9 @@ end
     # Integration test for aircraft just making sure everything runs
     ac = F16()
 
-
-    fcs = F16FCS()
-    set_stick_lon!(fcs, 0.0)
-    set_stick_lat!(fcs, 0.5)
-    set_pedals!(fcs, 0.5)
-    set_thtl!(fcs, 0.8)
+    fcs = get_fcs(ac)
+    controls = StickPedalsLeverControls(0.0, 0.5, 0.5, 0.8)
+    set_controls!(ac, controls)
 
     h = 0.0 * M2FT
     psi = 0.0  # rad
@@ -290,18 +289,25 @@ end
         exp_de   = trim_test_data[ii, 4]
 
         # Initial conditions for trimmer
-        α0 = exp_α*DEG2RAD + 5*DEG2RAD
+        α0 = 0.5*exp_α*DEG2RAD
         β0 = 0.
-        stick_lon0 = exp_de/25.0 + 0.5
-        thtl0 = exp_thtl + 0.3
+        stick_lon0 = 0.
+        thtl0 = 0.5
 
-        set_stick_lon!(fcs, stick_lon0)
-        set_thtl!(fcs, thtl0)
+        controls = StickPedalsLeverControls(
+            stick_lon0,
+            0.5,
+            0.5,
+            thtl0
+        )
 
-        ac, aerostate, state, fcs = steady_state_trim(
-            ac, fcs, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
+        set_controls!(ac, controls)
+
+        ac, aerostate, state, controls = steady_state_trim(
+            ac, controls, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
             )
 
+        fcs = get_fcs(ac)
         @test isapprox(ac.pfm.forces, zeros(3), atol=1e-7)
         @test isapprox(ac.pfm.moments, zeros(3), atol=1e-7)
         @test isapprox(get_tas(aerostate), tas)
@@ -321,17 +327,25 @@ end
         exp_de   = trim_test_data[ii, 4]
 
         # Initial conditions for trimmer
-        α0 = exp_α*DEG2RAD + 5*DEG2RAD
+        α0 = 0.5*exp_α*DEG2RAD
         β0 = 0.
-        stick_lon0 = exp_de/25.0 + 0.5
-        thtl0 = exp_thtl + 0.3
+        stick_lon0 = 0.
+        thtl0 = 0.5
 
-        set_stick_lon!(fcs, stick_lon0)
-        set_thtl!(fcs, thtl0)
+        controls = StickPedalsLeverControls(
+            stick_lon0,
+            0.5,
+            0.5,
+            thtl0
+        )
 
-        ac, aerostate, state, fcs = steady_state_trim(
-            ac, fcs, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
+        set_controls!(ac, controls)
+
+        ac, aerostate, state, controls = steady_state_trim(
+            ac, controls, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
             )
+
+        fcs = get_fcs(ac)
 
         @test isapprox(ac.pfm.forces, zeros(3), atol=1e-7)
         @test isapprox(ac.pfm.moments, zeros(3), atol=1e-7)
@@ -352,17 +366,25 @@ end
         exp_de   = trim_test_data[ii, 4]
 
         # Initial conditions for trimmer
-        α0 = exp_α*DEG2RAD + 5*DEG2RAD
+        α0 = 0.5*exp_α*DEG2RAD
         β0 = 0.
-        stick_lon0 = exp_de/25.0 + 0.5
-        thtl0 = exp_thtl + 0.3
+        stick_lon0 = 0.
+        thtl0 = 0.5
 
-        set_stick_lon!(fcs, stick_lon0)
-        set_thtl!(fcs, thtl0)
+        controls = StickPedalsLeverControls(
+            stick_lon0,
+            0.5,
+            0.5,
+            thtl0
+        )
 
-        ac, aerostate, state, fcs = steady_state_trim(
-            ac, fcs, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
+        set_controls!(ac, controls)
+
+        ac, aerostate, state, controls = steady_state_trim(
+            ac, controls, env, tas, pos, psi, gamma, turn_rate, α0, 0.0, show_trace=false
             )
+
+        fcs = get_fcs(ac)
 
         @test isapprox(ac.pfm.forces, zeros(3), atol=1e-7)
         @test isapprox(ac.pfm.moments, zeros(3), atol=1e-7)
@@ -384,7 +406,6 @@ end
     env = Environment(pos, atmos="ISAF16", wind="NoWind", grav="const")
 
     ac = F16()
-    fcs = F16FCS()
 
     h = 0.0 * M2FT
     psi = 0.234077 # rad
@@ -413,21 +434,27 @@ end
 
 
     # Initial conditions for trimmer
-    α0 = exp_α + 10*DEG2RAD
+    α0 = 0.5*exp_α*DEG2RAD
     β0 = 0.
-    stick_lon0 = exp_de/25.0 + 0.5
-    stick_lat0 = exp_da/21.5 + 0.5
-    pedals0 = exp_dr/30.0 + 0.5
-    thtl0 = exp_thtl + 0.3
+    stick_lon0 = 0.0
+    stick_lat0 = 0.0
+    pedals0 = 0.0
+    thtl0 = 0.5
 
-    set_stick_lon!(fcs, stick_lon0)
-    set_stick_lat!(fcs, stick_lat0)
-    set_pedals!(fcs, pedals0)
-    set_thtl!(fcs, thtl0)
-
-    ac, aerostate, state, fcs = steady_state_trim(
-        ac, fcs, env, tas, pos, psi, gamma, turn_rate, α0, β0, show_trace=false
+    controls = StickPedalsLeverControls(
+            stick_lon0,
+            stick_lat0,
+            pedals0,
+            thtl0
         )
+
+    set_controls!(ac, controls)
+
+    ac, aerostate, state, controls = steady_state_trim(
+        ac, controls, env, tas, pos, psi, gamma, turn_rate, α0, β0, show_trace=false
+        )
+
+    fcs = get_fcs(ac)
 
     @test isapprox(get_tas(aerostate), tas)
     @test isapprox(get_alpha(aerostate), exp_α, atol=5e-4)
@@ -498,7 +525,7 @@ end
                   [0., 0., 0.]
                  )
 
-    fcs = F16FCS()
+    fcs = get_fcs(ac)
     set_value!(fcs.de, 20.0*DEG2RAD)
     set_value!(fcs.da, -15.0*DEG2RAD)
     set_value!(fcs.dr, -20*DEG2RAD)
@@ -508,7 +535,7 @@ end
     aerostate = AeroState(state, env)
     grav = get_gravity(env)
 
-    ac = calculate_aircraft(ac, fcs, aerostate, state, grav; consume_fuel=false)
+    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
     pfm = ac.pfm
     mass_props = get_mass_props(ac)
     mass = mass_props.mass

--- a/test/models/dynamic_system.jl
+++ b/test/models/dynamic_system.jl
@@ -50,7 +50,8 @@ end
         [0., 0., 0.]
     )
 
-    fcs = F16FCS()
+    # Modify directly the deflexions of the surfaces on the FCS
+    fcs = get_fcs(ac)
     set_value!(fcs.de, 20.0*DEG2RAD)
     set_value!(fcs.da, -15.0*DEG2RAD)
     set_value!(fcs.dr, -20*DEG2RAD)
@@ -60,7 +61,7 @@ end
     aerostate = AeroState(state, env)
     grav = get_gravity(env)
 
-    ac = calculate_aircraft(ac, fcs, aerostate, state, grav; consume_fuel=false)
+    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
     pfm = ac.pfm
     mass_props = get_mass_props(ac)
     mass = mass_props.mass

--- a/test/models/dynamic_system.jl
+++ b/test/models/dynamic_system.jl
@@ -61,7 +61,7 @@ end
     aerostate = AeroState(state, env)
     grav = get_gravity(env)
 
-    ac = calculate_aircraft(ac, aerostate, state, grav; consume_fuel=false)
+    ac = calculate_aircraft(ac, controls, aerostate, state, grav; consume_fuel=false)
     pfm = ac.pfm
     mass_props = get_mass_props(ac)
     mass = mass_props.mass

--- a/test/models/fcs.jl
+++ b/test/models/fcs.jl
@@ -1,0 +1,16 @@
+using FlightMechanics.Models
+
+
+spl_stream = StickPedalsLeverStream(
+    ConstantInput(0.5),
+    vcat(DoubletInput(0.5, 1, 2), ConstantInput(0.25)),
+    vcat(RampInput(0.5, 1, 2), ConstantInput(0.1)),
+    ConstantInput(0.9)
+    )
+
+controls = get_controls(spl_stream, 0.)
+
+@test isapprox(controls.stick_lon, 0.5)
+@test isapprox(controls.stick_lat, 0.25)
+@test isapprox(controls.pedals, 0.1)
+@test isapprox(controls.thrust_lever, 0.9)

--- a/test/models/inputs.jl
+++ b/test/models/inputs.jl
@@ -6,7 +6,7 @@ ci_minus_one = ConstantInput(-1.0)
 
 @test isapprox(get_value(ci_one, 10.), 1.0)
 @test isapprox(get_value(ci_minus_one, 10.), -1.0)
-@test isapprox(get_value([ci_one, ci_minus_one], 10.), 0.0, atol=1e-15)
+@test isapprox(get_value(vcat(ci_one, ci_minus_one), 10.), 0.0, atol=1e-15)
 
 # StepInput
 si1 = StepInput(1.0, 5.0, 10.0)
@@ -19,9 +19,28 @@ si2 = StepInput(-1.0, 10.0, 15.0)
 @test isapprox(get_value(si2, 10.0), -1.0)
 @test isapprox(get_value(si2, 15.0), 0.0)
 
-@test isapprox(get_value([si1, si2], 8), 1.0)
-@test isapprox(get_value([si1, si2], 10), -1.0)
-@test isapprox(get_value([si1, si2], 12), -1.0)
+@test isapprox(get_value(vcat(si1, si2), 8), 1.0)
+@test isapprox(get_value(vcat(si1, si2), 10), -1.0)
+@test isapprox(get_value(vcat(si1, si2), 12), -1.0)
+
+# Doublet input
+d = DoubletInput(2, 0, 10)
+id = InverseDoubletInput(2, 0, 10)
+
+@test isapprox(get_value(d, 2.5), 1)
+@test isapprox(get_value(d, 5), -1)
+@test isapprox(get_value(d, 7.5), -1)
+@test isapprox(get_value(d, 10.), 0)
+
+@test isapprox(get_value(id, 2.5), -1)
+@test isapprox(get_value(id, 5), 1)
+@test isapprox(get_value(id, 7.5), 1)
+@test isapprox(get_value(id, 10.), 0)
+
+@test isapprox(get_value(vcat(d, id), 2.5), 0)
+@test isapprox(get_value(vcat(d, id), 5), 0)
+@test isapprox(get_value(vcat(d, id), 7.5), 0)
+@test isapprox(get_value(vcat(d, id), 10.), 0)
 
 # Ramp input
 r1 = RampInput(10, 0, 10)
@@ -34,9 +53,9 @@ r2 = RampInput(-10, 10, 15)
 @test isapprox(get_value(r2, 15.0), 0.0)
 @test isapprox(get_value(r2, 12.5), -5.0)
 
-@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 10), 10.0)
-@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 5), 5.0)
-@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 12.5), 5.0)
+@test isapprox(get_value(vcat(r1, r2, StepInput(10, 10, 15)), 10), 10.0)
+@test isapprox(get_value(vcat(r1, r2, StepInput(10, 10, 15)), 5), 5.0)
+@test isapprox(get_value(vcat(r1, r2, StepInput(10, 10, 15)), 12.5), 5.0)
 
 
 # Sinusoidal input

--- a/test/models/inputs.jl
+++ b/test/models/inputs.jl
@@ -1,0 +1,64 @@
+using FlightMechanics.Models
+
+# Constant input
+ci_one = ConstantInput(1.0)
+ci_minus_one = ConstantInput(-1.0)
+
+@test isapprox(get_value(ci_one, 10.), 1.0)
+@test isapprox(get_value(ci_minus_one, 10.), -1.0)
+@test isapprox(get_value([ci_one, ci_minus_one], 10.), 0.0, atol=1e-15)
+
+# StepInput
+si1 = StepInput(1.0, 5.0, 10.0)
+si2 = StepInput(-1.0, 10.0, 15.0)
+
+@test isapprox(get_value(si1, 0.0), 0.0)
+@test isapprox(get_value(si2, 0.0), 0.0)
+@test isapprox(get_value(si1, 5.0), 1.0)
+@test isapprox(get_value(si1, 10.0), 0.0)
+@test isapprox(get_value(si2, 10.0), -1.0)
+@test isapprox(get_value(si2, 15.0), 0.0)
+
+@test isapprox(get_value([si1, si2], 8), 1.0)
+@test isapprox(get_value([si1, si2], 10), -1.0)
+@test isapprox(get_value([si1, si2], 12), -1.0)
+
+# Ramp input
+r1 = RampInput(10, 0, 10)
+r2 = RampInput(-10, 10, 15)
+
+@test isapprox(get_value(r1, 0.0), 0.0)
+@test isapprox(get_value(r1, 10.0), 0.0)
+@test isapprox(get_value(r1, 5.0), 5.0)
+@test isapprox(get_value(r2, 10.0), 0.0)
+@test isapprox(get_value(r2, 15.0), 0.0)
+@test isapprox(get_value(r2, 12.5), -5.0)
+
+@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 10), 10.0)
+@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 5), 5.0)
+@test isapprox(get_value([r1, r2, StepInput(10, 10, 15)], 12.5), 5.0)
+
+
+# Sinusoidal input
+s = SinusoidalInput(2, 1, 0, 0, Inf)
+
+@test isapprox(get_value(s, 0), 0)
+@test isapprox(get_value(s, 1), 0, atol=1e-15)
+@test isapprox(get_value(s, 0.5), 0, atol=1e-15)
+@test isapprox(get_value(s, 0.25), 1)
+@test isapprox(get_value(s, 0.75), -1)
+
+sA = SinusoidalInput(20, 1, 0, 0, Inf)
+
+@test isapprox(get_value(sA, 0.25), 10)
+@test isapprox(get_value(sA, 0.75), -10)
+
+sf = SinusoidalInput(2, 2, 0, 0, Inf)
+
+@test isapprox(get_value(sf, 0.5), 0, atol=1e-15)
+@test isapprox(get_value(sf, 0.25), 0, atol=1e-15)
+
+sϕ = SinusoidalInput(2, 1, π/2, 0, Inf)
+
+@test isapprox(get_value(sϕ, 0), 1.0)
+@test isapprox(get_value(sϕ, 1), 1.0, atol=1e-15)

--- a/test/models/trimmer.jl
+++ b/test/models/trimmer.jl
@@ -54,6 +54,7 @@ fcs_trim = get_fcs(ac)
 # are the same.
 ac_calc = calculate_aircraft(
     ac_trim,
+    controls_trim,
     aerostate_trim,
     state_trim,
     get_gravity(env),

--- a/test/models/trimmer.jl
+++ b/test/models/trimmer.jl
@@ -7,12 +7,6 @@ using FlightMechanics.Models
 
 # Integration test for aircraft just making sure everything runs
 ac = F16()
-fcs = F16FCS()
-
-set_stick_lon!(fcs, 0.0)
-set_stick_lat!(fcs, 0.5)
-set_pedals!(fcs, 0.5)
-set_thtl!(fcs, 0.8)
 
 h = 0.0 * M2FT
 psi = 0.0  # rad
@@ -36,17 +30,15 @@ exp_de   = -0.756
 stick_lon0 = exp_de / 25.0 + 0.5
 thtl0 = exp_thtl + 0.3
 
-set_stick_lon!(fcs, stick_lon0)
-set_thtl!(fcs, thtl0)
+controls = StickPedalsLeverControls(stick_lon0, 0.5, 0.5, thtl0)
 
-fcs_before_trimming = copy(fcs)
+fcs_before_trimming = copy(get_fcs(ac))
 
-ac_trim, aerostate_trim, state_trim, fcs_trim = steady_state_trim(
-    ac, fcs, env, tas, pos, psi, gamma, turn_rate, α0, 0.0,
+ac_trim, aerostate_trim, state_trim, controls_trim = steady_state_trim(
+    ac, controls, env, tas, pos, psi, gamma, turn_rate, α0, 0.0,
     )
 
-# TEST: FCS has not been modified by trimmer
-@test isapprox(get_controls_trimmer(fcs), get_controls_trimmer(fcs_before_trimming))
+fcs_trim = get_fcs(ac)
 
 # TEST: Check results against Stevens (also checked in f16.jl tests)
 @test isapprox(ac_trim.pfm.forces, zeros(3), atol = 1e-7)
@@ -62,7 +54,6 @@ ac_trim, aerostate_trim, state_trim, fcs_trim = steady_state_trim(
 # are the same.
 ac_calc = calculate_aircraft(
     ac_trim,
-    fcs_trim,
     aerostate_trim,
     state_trim,
     get_gravity(env),
@@ -71,9 +62,9 @@ ac_calc = calculate_aircraft(
 @test isapprox(ac_trim.pfm.moments, ac_calc.pfm.moments)
 
 # TEST: Trim a trimmed aircraft and check if returns the same trim
-ac_trim2, aerostate_trim2, state_trim2, fcs_trim2 = steady_state_trim(
+ac_trim2, aerostate_trim2, state_trim2, controls_trim2 = steady_state_trim(
     ac_trim,
-    fcs_trim,
+    controls_trim,
     env,
     tas,
     pos,
@@ -83,6 +74,8 @@ ac_trim2, aerostate_trim2, state_trim2, fcs_trim2 = steady_state_trim(
     get_alpha(aerostate_trim),
     get_beta(aerostate_trim),
     )
+
+fcs_trim2 = get_fcs(ac)
 
 @test isapprox(get_tas(aerostate_trim2), tas)
 @test isapprox(get_beta(aerostate_trim2),  0.0, atol = 1e-13)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using FlightMechanics
 @testset "anemometry" begin include("anemometry.jl") end
 @testset "mechanics" begin include("mechanics.jl") end
 @testset "flight mechanics" begin include("flight_mechanics.jl") end
-
 @testset "inputs" begin include("models/inputs.jl") end
 @testset "fcs" begin include("models/fcs.jl") end
 @testset "pfm" begin include("models/point_forces_moments.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using FlightMechanics
 @testset "flight mechanics" begin include("flight_mechanics.jl") end
 
 @testset "inputs" begin include("models/inputs.jl") end
+@testset "fcs" begin include("models/fcs.jl") end
 @testset "pfm" begin include("models/point_forces_moments.jl") end
 @testset "mass" begin include("models/mass.jl") end
 @testset "attitude" begin include("models/attitude.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using FlightMechanics
 @testset "mechanics" begin include("mechanics.jl") end
 @testset "flight mechanics" begin include("flight_mechanics.jl") end
 
+@testset "inputs" begin include("models/inputs.jl") end
 @testset "pfm" begin include("models/point_forces_moments.jl") end
 @testset "mass" begin include("models/mass.jl") end
 @testset "attitude" begin include("models/attitude.jl") end


### PR DESCRIPTION
- [x] Types for basic inputs tested and documented
- [x] Type composition
- [x] Code a FCS type that can be passed to propagator to provide the inputs
- [x] Define a ControlsStream type containing Inputs with a getter to obtain controls at a certain instant
- [x] Define a Controls type that can be used to set fcs
- [x] Include FCS inside aircraft.
- [x] ~~Define a convert method to transform from Controls to ControlsStream (with ConstantInput)~~ Is it erally necessary now? Let's wait and see what seems more natural when setting streams for integration.
- [x] Adapt trimmer to receive Controls and return Controls
  - [x] Adapt trimmer doc. Remove references to FCS, add Controls
- [x] Remove *_controls_trimmer methods.
- [x] allow_out_of_range_controls and its error as FCS configuration
  - [x] ~~Avoid mutable struct~~ opened issue #66 
- [x] calculate_aircraft receiving controls argument instead of setting fcs outside
- [x] Open an issue to think about including Control in Controls and to think about the interaction of Controls and FCS. Opened #67 