### PR TITLE
Timestep propagator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/aircrafts/trimmer.jl
+++ b/src/aircrafts/trimmer.jl
@@ -75,6 +75,7 @@ function update_trimmer!(trimmer, α, β, controls)
         trimmer.ac, controls, aerostate, state, trimmer.env.grav;
         consume_fuel = false
         )
+    h = get_gyro_effects(get_propulsion(ac))
 
     # Evaluate dynamic system to get x_dot
     ds = convert(SixDOFEulerFixedMass, state)
@@ -87,7 +88,8 @@ function update_trimmer!(trimmer, α, β, controls)
         get_mass_props(ac).mass,
         get_mass_props(ac).inertia,
         ac.pfm.forces,
-        ac.pfm.moments
+        ac.pfm.moments,
+        h,
         )
 
         # Transform x, x_dot to State

--- a/src/dynamics/sixdof_euler_fixed_mass.jl
+++ b/src/dynamics/sixdof_euler_fixed_mass.jl
@@ -100,5 +100,7 @@ function six_dof_euler_fixed_mass(x, mass, inertia, forces, moments, h=[0.0, 0.0
     ye_dot =  cθ*sψ * u + (sϕ*sθ*sψ + cϕ*cψ) * v + (cϕ*sθ*sψ - sϕ*cψ) * w
     ze_dot = -sθ    * u +  sϕ*cθ             * v +  cϕ*cθ             * w
 
-    [u_dot, v_dot, w_dot, p_dot, q_dot, r_dot, ψ_dot, θ_dot, ϕ_dot, xe_dot, ye_dot, ze_dot]
+    x_dot = [u_dot, v_dot, w_dot, p_dot, q_dot, r_dot, ψ_dot, θ_dot, ϕ_dot, xe_dot, ye_dot, ze_dot]
+
+    return x_dot
 end

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -1,6 +1,6 @@
 module Models
 
-import Base: +, -, *, isapprox, convert, copy, show
+import Base: +, -, *, isapprox, convert, copy, show, push!, getindex, setindex!
 using LinearAlgebra
 using FlightMechanics
 
@@ -74,7 +74,9 @@ get_payload_mass_props, calculate_aircraft,
 # DynamicSystem
 SixDOFEulerFixedMass, SixDOFQuaternionFixedMass, SixDOFECEFQuaternionFixedMass,
 SixDOFAeroEulerFixedMass,
-get_state_equation, get_state_equation_ode_wrapper, get_x, get_x_count, get_state
+get_state_equation, get_state_equation_ode_wrapper, get_x, get_x_count, get_state,
+# Results Store
+ResultsStore
 
 include("attitude.jl")
 include("position.jl")
@@ -93,4 +95,5 @@ include("propulsion.jl")
 include("aerodynamics.jl")
 include("aircraft.jl")
 include("dynamic_systems.jl")
+include("results_store.jl")
 end

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -2,6 +2,7 @@ module Models
 
 import Base: +, -, *, isapprox, convert, copy, show, push!, getindex, setindex!
 using LinearAlgebra
+using OrdinaryDiffEq
 using FlightMechanics
 
 export
@@ -76,7 +77,9 @@ SixDOFEulerFixedMass, SixDOFQuaternionFixedMass, SixDOFECEFQuaternionFixedMass,
 SixDOFAeroEulerFixedMass,
 get_state_equation, get_state_equation_ode_wrapper, get_x, get_x_count, get_state,
 # Results Store
-ResultsStore
+ResultsStore,
+# Propagator
+propagate_timestep, propagate
 
 include("attitude.jl")
 include("position.jl")
@@ -96,4 +99,5 @@ include("aerodynamics.jl")
 include("aircraft.jl")
 include("dynamic_systems.jl")
 include("results_store.jl")
+include("propagator.jl")
 end

--- a/src/models/fcs.jl
+++ b/src/models/fcs.jl
@@ -139,3 +139,13 @@ function get_controls(cs::StickPedalsLeverStream, t)
     lev = get_value(cs.thrust_lever_stream, t)
     return StickPedalsLeverControls(slon, slat, ped, lev)
 end
+
+
+function convert(::Type{ControlsStream}, c::StickPedalsLeverControls)
+    StickPedalsLeverStream(
+        ConstantInput(get_stick_lon(c)),
+        ConstantInput(get_stick_lat(c)),
+        ConstantInput(get_pedals(c)),
+        ConstantInput(get_thrust_lever(c)),
+        )
+end

--- a/src/models/propagator.jl
+++ b/src/models/propagator.jl
@@ -1,6 +1,23 @@
-# TODO: DOC
+"""
+    propagate_timestep(
+        ac, controls, env, state, aerostate, tspan, dynamic_system, solver; 
+        solver_options=Dict(),
+    )
+
+Propagate tspan time step considering that the aircraft and the controls are constant.
+
+# Arguments
+`ac::Aircraft`: aircraft model. Includes engine, aerodynamics, flight control system...
+`controls::Controls`: controls that will be set on aircraft fot the timestep.
+`env::Environment`: environment model. Includes atmosphere, wind and gravity.
+`aerostate::AeroState`: aerodynamic state.
+`tspan`: tuple with tini and tfin (s).
+`dynamic_system::DynamicSystem`: dynamic system model equations to be integrated.
+`solver`: ODE solver from `OrdinaryDiffEq`.
+`solver_options`: options to be passed to the solver.
+"""
 function propagate_timestep(
-    ac, controls, env, state, aerostate, tspan, dynamic_system, solver; 
+    ac, controls, env, state, aerostate, tspan, dynamic_system, solver;
     solver_options=Dict(),
     )
 
@@ -54,7 +71,26 @@ function propagate_timestep(
 end
 
 
+"""
+    propagate(
+        ac, env, state, controls_stream, tini, tfin, dt, dynamic_system, solver;
+        solver_options=Dict()
+    )
 
+Integrate case to obtain aircraft trajectory by calling the solver for each time step.
+Returns a ResultsStore object.
+
+# Arguments
+`ac::Aircraft`: aircraft model. Includes engine, aerodynamics, flight control system...
+`env::Environment`: environment model. Includes atmosphere, wind and gravity.
+`controls_stream::ControlsStream`: defines a getter for each control at time `t`.
+`tini`: initial time (s).
+`tfin`: final time (s).
+`dt`: time step (s).
+`dynamic_system::DynamicSystem`: dynamic system model equations to be integrated.
+`solver`: ODE solver from `OrdinaryDiffEq`.
+`solver_options`: options to be passed to the solver.
+"""
 function propagate(
     ac, env, state, controls_stream, tini, tfin, dt, dynamic_system, solver;
     solver_options=Dict()

--- a/src/models/propagator.jl
+++ b/src/models/propagator.jl
@@ -1,0 +1,97 @@
+# TODO: DOC
+function propagate_timestep(
+    ac, controls, env, state, aerostate, tspan, dynamic_system, solver; 
+    solver_options=Dict(),
+    )
+
+    # Controls, Forces, moments, mass, inertia and gyro effects are assumed
+    # to be constant for the time step
+    ac = calculate_aircraft(ac, controls, aerostate, state, get_gravity(env))
+
+    # Unpack properties to match OrdinaryDiffEq interface
+    ac_mass_props = get_mass_props(ac)
+    ac_pfm = get_pfm(ac)
+    h = get_gyro_effects(get_propulsion(ac))
+
+    mass = get_mass(ac_mass_props)
+    inertia = get_inertia(ac_mass_props)
+    forces = get_forces(ac_pfm)
+    moments = get_moments(ac_pfm)
+
+    p = [mass, inertia, forces, moments, h]
+
+    x0 = get_x(dynamic_system, state)
+
+    # Create ODE problem
+    prob = ODEProblem(
+        get_state_equation_ode_wrapper(dynamic_system),
+        x0,
+        tspan,
+        p,
+    )
+    sol = solve(prob, solver, save_everystep = false, save_start = false; solver_options...)
+
+    if ~(sol.retcode == :Success)
+        error("Propagate time step did not converge from $(tspan[1]) to $(tspan[2])")
+    end
+
+    dynamic_system.x[:] = sol.u[1]
+    # TODO: is it possible to obtain this from solve?
+    dynamic_system.x_dot[:] = get_state_equation(dynamic_system)(sol.u[1], p...)
+
+    # Obtain state from sol
+    state = convert(state, dynamic_system)
+
+    # As the position has changed, environment changes (must be updated)
+    # and aircraft changes (must be updated)
+    # Calculate environment and aerostate for the current state
+    env = calculate_environment(env, get_position(state))
+    aerostate = AeroState(state, env)
+    # Calculate aircraft
+    ac = calculate_aircraft(ac, controls, aerostate, state, get_gravity(env))
+
+    return sol, ac, env, state, aerostate
+end
+
+
+
+function propagate(
+    ac, env, state, controls_stream, tini, tfin, dt, dynamic_system, solver;
+    solver_options=Dict()
+    )
+
+    # Prepare initial time step
+    t0 = tini
+    t1 = t0 + dt
+
+    # Create results object
+    aerostate = AeroState(state, env)
+    results = ResultsStore(tini, ac, env, state, aerostate)
+
+    while t1 < tfin + 0.5*dt
+        # Get controls
+        controls = get_controls(controls_stream, t0)
+
+        tspan = (t0, t1)
+        sol, ac, env, state, aerostate = propagate_timestep(
+            ac,
+            controls,
+            env,
+            state,
+            aerostate,
+            tspan,
+            dynamic_system,
+            solver;
+            solver_options=solver_options,
+        )
+
+        # Store
+        push!(results, t1, ac, env, state, aerostate)
+
+        # Prepare for next time step
+        t0 = t1
+        t1 = t1 + dt
+    end
+
+    return results
+end

--- a/src/models/propagator.jl
+++ b/src/models/propagator.jl
@@ -92,7 +92,7 @@ Returns a ResultsStore object.
 `solver_options`: options to be passed to the solver.
 """
 function propagate(
-    ac, env, state, controls_stream, tini, tfin, dt, dynamic_system, solver;
+    ac, env, state, aerostate, controls_stream, tini, tfin, dt, dynamic_system, solver;
     solver_options=Dict()
     )
 
@@ -101,7 +101,6 @@ function propagate(
     t1 = t0 + dt
 
     # Create results object
-    aerostate = AeroState(state, env)
     results = ResultsStore(tini, ac, env, state, aerostate)
 
     while t1 < tfin + 0.5*dt

--- a/src/models/results_store.jl
+++ b/src/models/results_store.jl
@@ -1,0 +1,34 @@
+struct ResultsStore
+    t :: Array{T, 1} where T <: Number
+    ac :: Array{T, 1} where T <: Aircraft
+    fcs :: Array{T, 1} where T <: FCS
+    env :: Array{T, 1} where T <: Environment
+    state :: Array{T, 1} where T <: State
+    aerostate :: Array{T, 1} where T <: AeroState
+end
+
+ResultsStore(t::Number, ac::Aircraft, fcs::FCS, env::Environment, state::State, aerostate::AeroState) = ResultsStore([t], [ac], [fcs], [env], [state], [aerostate])
+
+
+function push!(results::ResultsStore, t, ac, fcs, env, state, aerostate)
+    push!(results.t, t)
+    push!(results.ac, ac)
+    push!(results.fcs, fcs)
+    push!(results.env, env)
+    push!(results.state, state)
+    push!(results.aerostate, aerostate)
+end
+
+# Indexable collection
+function getindex(results::ResultsStore, ii)
+    return ResultsStore(results.t[ii], results.ac[ii], results.fcs[ii], results.env[ii], results.state[ii], results.aerostate[ii])
+end
+
+function set_index!(results::ResultsStore, value, ii)
+    results.t[ii] = value[0]
+    results.ac[ii] = value[1]
+    results.fcs[ii] = value[2]
+    results.env[ii] = value[3]
+    results.state[ii] = value[4]
+    results.aerostate[ii] = value[5]
+end

--- a/src/models/results_store.jl
+++ b/src/models/results_store.jl
@@ -1,3 +1,8 @@
+"""
+    ResultsStore(t, ac, env, state, aerostate)
+
+Store results for different timesteps.
+"""
 struct ResultsStore
     t :: Array{T, 1} where T <: Number
     ac :: Array{T, 1} where T <: Aircraft
@@ -20,10 +25,12 @@ function push!(results::ResultsStore, t, ac, env, state, aerostate)
     push!(results.aerostate, aerostate)
 end
 
+
 # Indexable collection
 function getindex(results::ResultsStore, ii)
     return ResultsStore(results.t[ii], results.ac[ii], results.fcs[ii], results.env[ii], results.state[ii], results.aerostate[ii])
 end
+
 
 function set_index!(results::ResultsStore, value, ii)
     results.t[ii] = value[1]

--- a/src/models/results_store.jl
+++ b/src/models/results_store.jl
@@ -1,19 +1,20 @@
 struct ResultsStore
     t :: Array{T, 1} where T <: Number
     ac :: Array{T, 1} where T <: Aircraft
-    fcs :: Array{T, 1} where T <: FCS
     env :: Array{T, 1} where T <: Environment
     state :: Array{T, 1} where T <: State
     aerostate :: Array{T, 1} where T <: AeroState
 end
 
-ResultsStore(t::Number, ac::Aircraft, fcs::FCS, env::Environment, state::State, aerostate::AeroState) = ResultsStore([t], [ac], [fcs], [env], [state], [aerostate])
+
+function ResultsStore(t::Number, ac::Aircraft, env::Environment, state::State, aerostate::AeroState)
+    ResultsStore([t], [ac], [env], [state], [aerostate])
+end
 
 
-function push!(results::ResultsStore, t, ac, fcs, env, state, aerostate)
+function push!(results::ResultsStore, t, ac, env, state, aerostate)
     push!(results.t, t)
     push!(results.ac, ac)
-    push!(results.fcs, fcs)
     push!(results.env, env)
     push!(results.state, state)
     push!(results.aerostate, aerostate)
@@ -25,9 +26,8 @@ function getindex(results::ResultsStore, ii)
 end
 
 function set_index!(results::ResultsStore, value, ii)
-    results.t[ii] = value[0]
-    results.ac[ii] = value[1]
-    results.fcs[ii] = value[2]
+    results.t[ii] = value[1]
+    results.ac[ii] = value[2]
     results.env[ii] = value[3]
     results.state[ii] = value[4]
     results.aerostate[ii] = value[5]

--- a/src/models/results_store.jl
+++ b/src/models/results_store.jl
@@ -28,7 +28,7 @@ end
 
 # Indexable collection
 function getindex(results::ResultsStore, ii)
-    return ResultsStore(results.t[ii], results.ac[ii], results.fcs[ii], results.env[ii], results.state[ii], results.aerostate[ii])
+    return ResultsStore(results.t[ii], results.ac[ii], results.env[ii], results.state[ii], results.aerostate[ii])
 end
 
 

--- a/test/aircrafts/f16.jl
+++ b/test/aircrafts/f16.jl
@@ -457,18 +457,18 @@ end
     fcs = get_fcs(ac)
 
     @test isapprox(get_tas(aerostate), tas)
-    @test isapprox(get_alpha(aerostate), exp_α, atol=5e-4)
-    @test isapprox(get_beta(aerostate), exp_β, atol=5e-5)
+    @test isapprox(get_alpha(aerostate), exp_α, atol=1e-4)
+    @test isapprox(get_beta(aerostate), exp_β, atol=1e-7)
 
-    @test isapprox(get_body_ang_velocity(state), [exp_p, exp_q, exp_r], atol=5e-5)
-    @test isapprox(get_euler_angles(state), [exp_ψ, exp_θ, exp_ϕ], atol=5e-5)
+    @test isapprox(get_body_ang_velocity(state), [exp_p, exp_q, exp_r], atol=1e-4)
+    @test isapprox(get_euler_angles(state), [exp_ψ, exp_θ, exp_ϕ], atol=1e-4)
 
     # TODO: maybe these tolerances are too broad. Take into account that trim in
     # Stevens is only based in the number of iterations.
-    @test isapprox(fcs.thtl.value, exp_thtl, atol=5e-4)
-    @test isapprox(fcs.de.value*RAD2DEG, exp_de, rtol=1e-2)
-    @test isapprox(fcs.da.value*RAD2DEG, exp_da, rtol=1e-2)
-    @test isapprox(fcs.dr.value*RAD2DEG, exp_dr, rtol=1e-1)
+    @test isapprox(fcs.thtl.value, exp_thtl, atol=1e-3)
+    @test isapprox(fcs.de.value*RAD2DEG, exp_de, atol=2e-3)
+    @test isapprox(fcs.da.value*RAD2DEG, exp_da, atol=1e-4)
+    @test isapprox(fcs.dr.value*RAD2DEG, exp_dr, atol=1e-4)
 end
 
 

--- a/test/flight_mechanics.jl
+++ b/test/flight_mechanics.jl
@@ -32,11 +32,11 @@ qdot = body_angular_velocity_to_quaternion_rates(p, q, r, quat...)
 exp_tas = 100  # m/s
 exp_α = 0.01  # rad
 exp_β = 0.005  # rad
-u, v, w = wind2body(tas, 0, 0, exp_α, exp_β)
+u, v, w = wind2body(exp_tas, 0, 0, exp_α, exp_β)
 tas, α, β = uvw_to_tasαβ(u, v, w)
 @test isapprox(tas, exp_tas)
 @test isapprox(α, exp_α)
-@test isapprox(β, exp_β, atol=1e-7)
+@test isapprox(β, exp_β)
 
 
 # Test tas_α_β_dot_from_uvw_dot
@@ -58,4 +58,4 @@ tas = √(u*u + v*v + w*w)
 # tas_α_β_dot_from_uvw_dot <--> uvw_dot_from_tas_α_β
 tas, α, β = uvw_to_tasαβ(u, v, w)
 u_dot_, v_dot_, w_dot_ = uvw_dot_from_tas_α_β(tas, α, β, tas_dot, α_dot, β_dot)
-@test isapprox([u_dot, v_dot, w_dot], [u_dot_, v_dot_, w_dot_], atol=1e-4)
+@test isapprox([u_dot, v_dot, w_dot], [u_dot_, v_dot_, w_dot_])

--- a/test/models/propagate_constant_inputs.jl
+++ b/test/models/propagate_constant_inputs.jl
@@ -6,8 +6,6 @@ using FlightMechanics.Models
 
 # Choose aircraft
 ac = F16()
-# Choose Flight Control System
-fcs = F16FCS()
 # Choose dynamic system
 dynamic_system = SixDOFEulerFixedMass()
 # Choose solver

--- a/test/models/propagate_constant_inputs.jl
+++ b/test/models/propagate_constant_inputs.jl
@@ -57,6 +57,7 @@ times_to_test = [0.1, 1.0, 10.0, 100.0]  # seconds
         ac,
         env,
         state,
+        aerostate,
         controls_stream,
         tini,
         tfin,

--- a/test/models/propagate_constant_inputs.jl
+++ b/test/models/propagate_constant_inputs.jl
@@ -1,0 +1,108 @@
+using LinearAlgebra
+using OrdinaryDiffEq
+using FlightMechanics.Aircrafts
+using FlightMechanics.Models
+
+
+# Choose aircraft
+ac = F16()
+# Choose Flight Control System
+fcs = F16FCS()
+# Choose dynamic system
+dynamic_system = SixDOFEulerFixedMass()
+# Choose solver
+solver = RK4()
+solver_options = Dict()
+
+# Initilizations
+h = 1000.0 * M2FT
+tas = 250 * KT2MS
+psi = 0.0  # rad
+gamma = 0.0
+turn_rate = 0.0
+
+pos = EarthPosition(0, 0, -h)
+
+# Initilize environment
+env = Environment(pos, atmos = "ISAF16", wind = "NoWind", grav = "const")
+
+att = Attitude(-1, 0.1, 0.0)
+
+# Initilize FCS
+controls_0 = StickPedalsLeverControls(0.0, 0.5, 0.5, 0.8)
+
+# Trim a/c
+ac, aerostate, state, controls = steady_state_trim(
+    ac,
+    controls_0,
+    env,
+    tas,
+    pos,
+    psi,
+    gamma,
+    turn_rate,
+    0.0,
+    0.0,
+    show_trace = false,
+    )
+
+controls_stream = convert(ControlsStream, controls)
+
+times_to_test = [0.1, 1.0, 10.0, 100.0]  # seconds
+
+@testset "Simulation time $t s" for t=times_to_test
+    tini = 0.0
+    tfin = t
+    dt = 0.01
+
+    results = propagate(
+        ac,
+        env,
+        state,
+        controls_stream,
+        tini,
+        tfin,
+        dt,
+        dynamic_system,
+        solver;
+        solver_options=solver_options
+        )
+
+    @test isapprox(
+        results.state[1].attitude,
+        results.state[end].attitude,
+    )
+
+    @test isapprox(
+        results.state[1].velocity,
+        results.state[end].velocity,
+    )
+
+    @test isapprox(
+        results.state[1].angular_velocity,
+        results.state[end].angular_velocity,
+        atol=1e-11
+    )
+
+    @test isapprox(
+        results.state[1].acceleration,
+        results.state[end].acceleration,
+        atol=1e-10
+    )
+
+    @test isapprox(
+        results.state[1].angular_acceleration,
+        results.state[end].angular_acceleration,
+        atol=1e-12
+    )
+
+    @test isapprox(
+        get_height(results.state[1]),
+        get_height(results.state[end]),
+        )
+
+    @test isapprox(
+        norm(get_xyz_earth(results.state[1])[1:2] - get_xyz_earth(results.state[end])[1:2]),
+        tas * (tfin - tini),
+        )
+end

--- a/test/models/propagate_coordinated_turn.jl
+++ b/test/models/propagate_coordinated_turn.jl
@@ -1,6 +1,7 @@
 using FlightMechanics
 using FlightMechanics.Aircrafts
 using FlightMechanics.Models
+using OrdinaryDiffEq
 
 
 # Stevens, B. L., Lewis, F. L., & Johnson, E. N. (2015). Aircraft control
@@ -27,8 +28,6 @@ pos = EarthPosition(0, 0, -h)
 
 # Initilize environment
 env = Environment(pos, atmos = "ISAF16", wind = "NoWind", grav = "const")
-
-att = Attitude(0.0, 0.1, 0.1)
 
 # Initilize FCS
 controls_0 = StickPedalsLeverControls(0.5, 0.5, 0.5, 0.8)
@@ -58,6 +57,7 @@ results = propagate(
     ac,
     env,
     state,
+    aerostate,
     controls_stream,
     tini,
     tfin,

--- a/test/models/propagate_coordinated_turn.jl
+++ b/test/models/propagate_coordinated_turn.jl
@@ -1,0 +1,108 @@
+using FlightMechanics
+using FlightMechanics.Aircrafts
+using FlightMechanics.Models
+
+
+# Stevens, B. L., Lewis, F. L., & Johnson, E. N. (2015). Aircraft control
+#  and simulation: dynamics, controls design, and autonomous systems. John Wiley
+#  & Sons.
+# Example 3.6-5: Simulation of a Coordinated Turn (page 197)
+
+# Choose aircraft
+ac = F16()
+# Choose dynamic system
+dynamic_system = SixDOFEulerFixedMass()
+# Choose solver
+solver = RK4()
+solver_options = Dict()
+
+# Initilizations
+h = 0.0 * M2FT
+tas = 502 * FT2M
+psi = 0.0  # rad
+gamma = 0.0  # rad
+turn_rate = 0.3  # rad/s
+
+pos = EarthPosition(0, 0, -h)
+
+# Initilize environment
+env = Environment(pos, atmos = "ISAF16", wind = "NoWind", grav = "const")
+
+att = Attitude(0.0, 0.1, 0.1)
+
+# Initilize FCS
+controls_0 = StickPedalsLeverControls(0.5, 0.5, 0.5, 0.8)
+
+# Trim a/c
+ac, aerostate, state, controls = steady_state_trim(
+    ac,
+    controls_0,
+    env,
+    tas,
+    pos,
+    psi,
+    gamma,
+    turn_rate,
+    0.0,
+    0.0,
+    show_trace = false,
+    )
+
+controls_stream = convert(ControlsStream, controls)
+
+tini = 0.0
+tfin = 180
+dt = 0.01
+
+results = propagate(
+    ac,
+    env,
+    state,
+    controls_stream,
+    tini,
+    tfin,
+    dt,
+    dynamic_system,
+    solver;
+    solver_options=solver_options
+    )
+
+@test isapprox(
+    get_height(results.state[1]),
+    get_height(results.state[end]),
+    )
+
+@test isapprox(
+    get_euler_angles(results.state[1])[2],
+    get_euler_angles(results.state[end])[2],
+)
+
+@test isapprox(
+    get_euler_angles(results.state[1])[3],
+    get_euler_angles(results.state[end])[3],
+)
+
+@test isapprox(
+    get_tas(results.aerostate[1]),
+    get_tas(results.aerostate[end]),
+)
+
+@test isapprox(
+    get_alpha(results.aerostate[1]),
+    get_alpha(results.aerostate[end]),
+)
+
+@test isapprox(
+    get_beta(results.aerostate[1]),
+    get_beta(results.aerostate[end]),
+)
+
+@test isapprox(
+    results.state[1].acceleration,
+    results.state[end].acceleration,
+)
+
+@test isapprox(
+    results.state[1].angular_acceleration,
+    results.state[end].angular_acceleration,
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ using FlightMechanics
 @testset "aerostate" begin include("models/aero_state.jl") end
 @testset "dynamic system" begin include("models/dynamic_system.jl") end
 @testset "trimmer" begin include("models/trimmer.jl") end
+@testset "propagate_constant_inputs" begin include("models/propagate_constant_inputs.jl") end
 
 @testset "ac: c310" begin include("aircrafts/c310.jl") end
 @testset "ac: f16" begin include("aircrafts/f16.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using FlightMechanics
 @testset "dynamic system" begin include("models/dynamic_system.jl") end
 @testset "trimmer" begin include("models/trimmer.jl") end
 @testset "propagate_constant_inputs" begin include("models/propagate_constant_inputs.jl") end
+@testset "propagate_coordinated_turn" begin include("models/propagate_coordinated_turn.jl") end
 
 @testset "ac: c310" begin include("aircrafts/c310.jl") end
 @testset "ac: f16" begin include("aircrafts/f16.jl") end


### PR DESCRIPTION
 Rewriting of work in #48 with a cleaner history 

# Roadmap

- [x] Implement a basic type to store results
  - [ ] Open an issue to improve `ResultsStore` with desirable features (plotiing, show, variables setup...) 
- [x] Basic implementation of a propagator based on OrdinaryDiffEq (#46)
  - [x] Trimmed aircraft remains stable after propagation
- [x] close #64
- [x] Rebase master 
- [x] Receive inputs as an argument of the propagation
- [x] Documentation of propagate and propagate_time_step functions
- [x] Documentation of ResultsStore
- [ ] Tests generalization
  - [ ] Stevens coordinated turn for F16 (WIP)
    * TESTS currently not passing. It probably has to do with coarse tolerances in https://github.com/AlexS12/FlightMechanics.jl/blob/master/test/aircrafts/f16.jl#L466
    * Check the integration with the expected trim outputs to discard a problem in the propagation loop 
    * solve https://github.com/AlexS12/FlightMechanics.jl/issues/69 to check against:
![image](https://user-images.githubusercontent.com/6061587/81594000-8b66de80-93c0-11ea-80c0-fea90b5bc849.png)
    * implement a test for X10, X11 (North, East):
![image](https://user-images.githubusercontent.com/6061587/81593901-62464e00-93c0-11ea-8819-c97a13167fea.png)

  - [ ] Test all the dynamic systems
  - [ ] Test C310 aircraft
  - [ ] Test solve options